### PR TITLE
Fix: Set headers when request data is null

### DIFF
--- a/src/httpClient/applyDefaultInterceptors.js
+++ b/src/httpClient/applyDefaultInterceptors.js
@@ -20,7 +20,7 @@ export default (store, client) => {
         uid
       };
     }
-    config.data = humps.decamelizeKeys(data);
+    config.data = data ? humps.decamelizeKeys(data) : {};
     return config;
   });
 

--- a/src/httpClient/index.js
+++ b/src/httpClient/index.js
@@ -6,10 +6,8 @@ const CONTENT_TYPE = 'Content-Type';
 const client = axios.create({
   baseURL: process.env.API_URL,
   headers: {
-    common: {
-      Accept: APPLICATION_JSON,
-      [CONTENT_TYPE]: APPLICATION_JSON
-    }
+    Accept: APPLICATION_JSON,
+    [CONTENT_TYPE]: APPLICATION_JSON
   }
 });
 

--- a/src/httpClient/index.js
+++ b/src/httpClient/index.js
@@ -6,8 +6,10 @@ const CONTENT_TYPE = 'Content-Type';
 const client = axios.create({
   baseURL: process.env.API_URL,
   headers: {
-    Accept: APPLICATION_JSON,
-    [CONTENT_TYPE]: APPLICATION_JSON
+    common: {
+      Accept: APPLICATION_JSON,
+      [CONTENT_TYPE]: APPLICATION_JSON
+    }
   }
 });
 

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -6,7 +6,7 @@ class UserService {
   }
 
   static logout() {
-    return httpClient.delete('/users/sign_out', { data: {} });
+    return httpClient.delete('/users/sign_out');
   }
 
   static signUp(user) {


### PR DESCRIPTION
# Fix: Set headers when request data is null
### Description 
- Changed `applyDefaultInterceptors.js`  for set data as an empty object (`{}`), this allows set the content type even for empty requests.

### Docs 📚 
- [Why axios remove the headers for empty request? (line 119)](https://github.com/axios/axios/blob/dc4bc49673943e35280e5df831f5c3d0347a9393/lib/adapters/xhr.js)