### PR TITLE
Replace redux-tools with redux-toolkit

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
   "printWidth": 100,
-  "singleQuote": true,
+  "singleQuote": true
 }

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Dependency Status](https://img.shields.io/david/rootstrap/react-redux-base.svg)](https://david-dm.org/rootstrap/react-redux-base)
 [![License](https://img.shields.io/github/license/rootstrap/react-redux-base.svg)](https://github.com/rootstrap/react-redux-base/blob/master/LICENSE.md)
 
-
 ## Commands
+
 1. **Run the app**. `yarn start` or `npm start`
 2. **Build the app**. `yarn build` or `npm run build`
 3. **Lint the app**. `yarn lint` or `npm run lint`
@@ -15,31 +15,37 @@
 5. **Run the app with SSR**. `yarn ssr` or `npm run ssr`
 
 ## Getting Started
+
 1. Clone the repository
 2. Install dependencies: `yarn` or `npm install`
 3. Create the environment variables files in root folder(.env.dev, .env.staging and .env.prod):
 
-  `.env.example` example:
-  ```
-    API_URL=http://your-api-url.com
-    AWS_BUCKET=bucket
-    AWS_REGION=region
-    AWS_ACCESS_KEY_ID=key_id
-    AWS_SECRET_ACCESS_KEY=secret_key
-  ```
+`.env.example` example:
+
+```
+  API_URL=http://your-api-url.com
+  AWS_BUCKET=bucket
+  AWS_REGION=region
+  AWS_ACCESS_KEY_ID=key_id
+  AWS_SECRET_ACCESS_KEY=secret_key
+```
+
 4. Start the dev server: `yarn start` or `npm start -s`
 
 ## Running script with different environments
+
 To change the set of environment variables for a script it's needed to run ENV=my_environment before the script.
 
 For example: `ENV=staging yarn build`
 
 ## Configuring Code Climate
+
 1. After adding the project to CC, go to `Repo Settings`
 2. On the `Test Coverage` tab, copy the `Test Reporter ID`
 3. Replace the current value of `CC_TEST_REPORTER_ID` on the `config.yml file (.circleci/config.yml)` with the one you copied from CC
 
 ## Initial Machine Setup
+
 **Install [Node 7.0.0 or greater, 10.14.2 LTS preferred](https://nodejs.org)**
 Project is currently set to node version `10.14.2 LTS`. Make sure that you are using the node version specified in the `package.json`, if you prefer to use a different one you can change it there.
 
@@ -47,48 +53,51 @@ Project is currently set to node version `10.14.2 LTS`. Make sure that you are u
 
 ## Redux setup
 
-The base makes use of our [redux-tools](http://github.com/rootstrap/redux-tools) package.
+The base makes use of the [redux-toolkit](https://github.com/reduxjs/redux-toolkit) package.
 This makes working with, and tracking the status of async side effect easier.
-Learn more about this in the redux-tools [readme](https://github.com/rootstrap/redux-tools/blob/master/README.md).
-
+Learn more about this in the redux-toolkit [docs](https://redux-toolkit.js.org/introduction/quick-start).
 
 ## Server Side Rendering
+
 This base is already set up with a Node server for SSR.
 
 The command `yarn ssr` will compile the server and client.
 
 ### Fetching data
+
 The server is prepared to fetch data directly from the backend before rendering the HTML.
 
 ## Deploying to AWS S3
+
 1. **Add the environment variables for each .env** AWS_BUCKET, AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 2. **Run the command to deploy with an environment** `ENV=your_environment yarn deploy`
 
 ## Deploying to Heroku
+
 1. **Add all the environment variables in .env to Heroku**
 2. **Add the env variable NPM_CONFIG_PRODUCTION=false to Heroku**
-2. **Deploy your branch to Heroku**
+3. **Deploy your branch to Heroku**
 
 ## Technologies
 
-| **Tech** | **Description**
-|----------|-------
-|  [React](https://facebook.github.io/react/)  |   Fast, composable client-side components.|
-|  [Redux](http://redux.js.org) |  Enforces unidirectional data flows and immutable, hot reloadable store. Supports time-travel debugging.|
-|  [React Router 5](https://github.com/reactjs/react-router) | A complete routing library for React |
-|  [Babel](http://babeljs.io) |  Compiles ES6 to ES5. Enjoy the new version of JavaScript today.|
-| [Webpack 4](http://webpack.github.io) | Bundles npm packages and our JS into a single file. Includes hot reloading via [React Hot Loader](https://github.com/gaearon/react-hot-loader). |
-| [Express](https://github.com/expressjs/express) | Fast, unopinionated, minimalist web framework for node. |
-| [Cypress](https://cypress.io/) | Automated integration tests. Default way of testing. |
-| [Jest](https://facebook.github.io/jest/) | Automated tests with built-in expect assertions and  [Enzyme](https://github.com/airbnb/enzyme) for DOM testing without a browser using Node. |
-| [ESLint](http://eslint.org/)| Lint JS. Reports syntax and style issues. Using [eslint-config-airbnb](https://www.npmjs.com/package/eslint-config-airbnb) for the airbnb style guides. |
-| [SASS](http://sass-lang.com/) | Compiled CSS styles with variables, functions, and more.
-| [PostCSS](https://github.com/postcss/postcss) | Transform styles with JS plugins. Used to autoprefix CSS |
-| [Stylelint](https://github.com/stylelint/stylelint) | Modern CSS linter that helps you enforce consistent conventions and avoid errors in your stylesheets. |
-| [Redux Persist](https://github.com/rt2zz/redux-persist) | Persist and rehydrate your redux store |
-| [Immer](https://github.com/immerjs/immer) | Allows you to work with immutable state in a more convenient way. |
-| [React Intl](https://github.com/yahoo/react-intl/) | Localization for language support. |
-| [Rootstrap UI](https://github.com/rootstrap/rootstrap-ui/) | Rootstrap UI is the components & styles library to build user interfaces |
+| **Tech**                                                   | **Description**                                                                                                                                         |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [React](https://facebook.github.io/react/)                 | Fast, composable client-side components.                                                                                                                |
+| [Redux](http://redux.js.org)                               | Enforces unidirectional data flows and immutable, hot reloadable store. Supports time-travel debugging.                                                 |
+| [React Router 5](https://github.com/reactjs/react-router)  | A complete routing library for React                                                                                                                    |
+| [Babel](http://babeljs.io)                                 | Compiles ES6 to ES5. Enjoy the new version of JavaScript today.                                                                                         |
+| [Webpack 4](http://webpack.github.io)                      | Bundles npm packages and our JS into a single file. Includes hot reloading via [React Hot Loader](https://github.com/gaearon/react-hot-loader).         |
+| [Express](https://github.com/expressjs/express)            | Fast, unopinionated, minimalist web framework for node.                                                                                                 |
+| [Cypress](https://cypress.io/)                             | Automated integration tests. Default way of testing.                                                                                                    |
+| [Jest](https://facebook.github.io/jest/)                   | Automated tests with built-in expect assertions and [Enzyme](https://github.com/airbnb/enzyme) for DOM testing without a browser using Node.            |
+| [ESLint](http://eslint.org/)                               | Lint JS. Reports syntax and style issues. Using [eslint-config-airbnb](https://www.npmjs.com/package/eslint-config-airbnb) for the airbnb style guides. |
+| [SASS](http://sass-lang.com/)                              | Compiled CSS styles with variables, functions, and more.                                                                                                |
+| [PostCSS](https://github.com/postcss/postcss)              | Transform styles with JS plugins. Used to autoprefix CSS                                                                                                |
+| [Stylelint](https://github.com/stylelint/stylelint)        | Modern CSS linter that helps you enforce consistent conventions and avoid errors in your stylesheets.                                                   |
+| [Redux Persist](https://github.com/rt2zz/redux-persist)    | Persist and rehydrate your redux store                                                                                                                  |
+| [Immer](https://github.com/immerjs/immer)                  | Allows you to work with immutable state in a more convenient way.                                                                                       |
+| [React Intl](https://github.com/yahoo/react-intl/)         | Localization for language support.                                                                                                                      |
+| [Rootstrap UI](https://github.com/rootstrap/rootstrap-ui/) | Rootstrap UI is the components & styles library to build user interfaces                                                                                |
 
 ## License
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -51,7 +51,7 @@ Cypress.Commands.add('loginUser', () => {
     .its('store')
     .then(store => {
       store.dispatch(updateSession(session()));
-      store.dispatch(login.success(user()));
+      store.dispatch(login.fulfilled(user()));
     });
 });
 
@@ -71,7 +71,7 @@ Cypress.Commands.add('realLoginUser', () => {
           .its('store')
           .then(store => {
             store.dispatch(updateSession(session));
-            store.dispatch(login.success(user));
+            store.dispatch(login.fulfilled(user));
           });
       }
     }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "description": "Rootstrap React Redux Base",
   "engines": {
-    "npm": ">4",
-    "node": "12.18.2"
+    "npm": ">4"
   },
   "scripts": {
     "preinstall": "node tools/nodeVersionCheck.js",
@@ -63,7 +62,7 @@
   "license": "MIT",
   "dependencies": {
     "@formatjs/intl-relativetimeformat": "2.6.3",
-    "@rootstrap/redux-tools": "1.0.0",
+    "@reduxjs/toolkit": "1.4.0",
     "@rootstrap/validate": "1.0.0",
     "axios": "0.19.2",
     "classnames": "2.2.6",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "redux": "4.0.4",
     "redux-logger": "3.0.6",
     "redux-persist": "6.0.0",
-    "reselect": "4.0.0",
     "rootstrap-ui": "0.0.2"
   },
   "devDependencies": {

--- a/src/components/user/LoginForm.js
+++ b/src/components/user/LoginForm.js
@@ -1,12 +1,13 @@
 import React, { memo } from 'react';
 import { func } from 'prop-types';
 import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
-import { useStatus, ERROR, LOADING } from '@rootstrap/redux-tools';
+
+import { REJECTED, PENDING } from 'constants/actionStatusConstants';
 
 import Loading from 'components/common/Loading';
 import Input from 'components/common/Input';
 import { login as loginValidations } from 'utils/constraints';
-import { useForm, useValidation, useTextInputProps } from 'hooks';
+import { useStatus, useForm, useValidation, useTextInputProps } from 'hooks';
 import { login } from 'state/actions/userActions';
 
 const messages = defineMessages({
@@ -53,7 +54,7 @@ export const LoginForm = ({ onSubmit }) => {
 
   return (
     <form onSubmit={handleSubmit}>
-      {status === ERROR && <strong>{error}</strong>}
+      {status === REJECTED && <strong>{error}</strong>}
       <div>
         <Input
           name="email"
@@ -73,7 +74,7 @@ export const LoginForm = ({ onSubmit }) => {
       <button type="submit">
         <FormattedMessage id="login.form.submit" />
       </button>
-      {status === LOADING && <Loading />}
+      {status === PENDING && <Loading />}
     </form>
   );
 };

--- a/src/components/user/SignUpForm.js
+++ b/src/components/user/SignUpForm.js
@@ -1,12 +1,13 @@
 import React, { memo } from 'react';
 import { func } from 'prop-types';
 import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
-import { useStatus, ERROR, LOADING } from '@rootstrap/redux-tools';
+
+import { REJECTED, PENDING } from 'constants/actionStatusConstants';
 
 import Loading from 'components/common/Loading';
 import Input from 'components/common/Input';
 import { signUp as signUpValidations } from 'utils/constraints';
-import { useForm, useValidation, useTextInputProps } from 'hooks';
+import { useStatus, useForm, useValidation, useTextInputProps } from 'hooks';
 import { signUp } from 'state/actions/userActions';
 
 const messages = defineMessages({
@@ -56,7 +57,7 @@ export const SignUpForm = ({ onSubmit }) => {
 
   return (
     <form onSubmit={handleSubmit}>
-      {status === ERROR && <strong>{error}</strong>}
+      {status === REJECTED && <strong>{error}</strong>}
       <div>
         <Input
           name="email"
@@ -84,7 +85,7 @@ export const SignUpForm = ({ onSubmit }) => {
       <button type="submit">
         <FormattedMessage id="login.form.submit" />
       </button>
-      {status === LOADING && <Loading />}
+      {status === PENDING && <Loading />}
     </form>
   );
 };

--- a/src/constants/actionStatusConstants.js
+++ b/src/constants/actionStatusConstants.js
@@ -1,4 +1,3 @@
-export const NOT_STARTED = 'NOT_STARTED';
-export const PENDING = 'PENDING';
-export const FULFILLED = 'FULFILLED';
-export const REJECTED = 'REJECTED';
+export const PENDING = 'pending';
+export const FULFILLED = 'fulfilled';
+export const REJECTED = 'rejected';

--- a/src/constants/actionStatusConstants.js
+++ b/src/constants/actionStatusConstants.js
@@ -1,0 +1,4 @@
+export const NOT_STARTED = 'NOT_STARTED';
+export const PENDING = 'PENDING';
+export const FULFILLED = 'FULFILLED';
+export const REJECTED = 'REJECTED';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -4,3 +4,4 @@ export { default as useForm } from './useForm';
 export { default as useValidation } from './useValidation';
 export { default as useTextInputProps } from './useTextInputProps';
 export { default as useSelectOptions } from './useSelectOptions';
+export { default as useStatus } from './useStatus';

--- a/src/hooks/useStatus.js
+++ b/src/hooks/useStatus.js
@@ -1,0 +1,21 @@
+import { useSelector } from 'react-redux';
+
+/**
+ * useStatus hook
+ *
+ * @param {string} action Prefix for the action names
+ *
+ * @returns {object} Object with status and error keys
+ *
+ * @example
+ * const { status, error } = useStatus(login)
+ */
+
+export default action =>
+  useSelector(({ statusReducer }) => {
+    const { status, error } = statusReducer[(action?.typePrefix)] || {};
+    return {
+      status,
+      error
+    };
+  });

--- a/src/state/actions/userActions.js
+++ b/src/state/actions/userActions.js
@@ -31,3 +31,7 @@ export const signUp = createAsyncThunk('user/signup', async user => {
 });
 
 export const updateSession = createAction('session/update');
+
+export const { fulfilled: loginFulfilled, rejected: loginRejected } = login;
+export const { fulfilled: signUpFulfilled } = signUp;
+export const { fulfilled: logoutFulfilled } = logout;

--- a/src/state/actions/userActions.js
+++ b/src/state/actions/userActions.js
@@ -1,8 +1,8 @@
-import { createThunk, createAction } from '@rootstrap/redux-tools';
+import { createAsyncThunk, createAction } from '@reduxjs/toolkit';
 import userService from 'services/userService';
 import parseError from 'utils/parseError';
 
-export const login = createThunk('LOGIN', async user => {
+export const login = createAsyncThunk('user/login', async user => {
   try {
     const {
       data: { data }
@@ -13,7 +13,7 @@ export const login = createThunk('LOGIN', async user => {
   }
 });
 
-export const logout = createThunk('LOGOUT', async () => {
+export const logout = createAsyncThunk('user/logout', async () => {
   try {
     await userService.logout();
   } catch ({ response: { data } }) {
@@ -21,7 +21,7 @@ export const logout = createThunk('LOGOUT', async () => {
   }
 });
 
-export const signUp = createThunk('SIGNUP', async user => {
+export const signUp = createAsyncThunk('user/signup', async user => {
   try {
     const { data } = await userService.signUp({ user });
     return data;
@@ -30,4 +30,4 @@ export const signUp = createThunk('SIGNUP', async user => {
   }
 });
 
-export const updateSession = createAction('UPDATE_SESSION');
+export const updateSession = createAction('session/update');

--- a/src/state/reducers/index.js
+++ b/src/state/reducers/index.js
@@ -3,7 +3,7 @@ import localForage from 'localforage';
 import { persistReducer } from 'redux-persist';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 
-import { statusReducer } from '@rootstrap/redux-tools';
+import statusReducer from './statusReducer';
 import session from './sessionReducer';
 
 const sessionPersistConfig = {
@@ -13,10 +13,9 @@ const sessionPersistConfig = {
   stateReconciler: autoMergeLevel2
 };
 
-const rootReducer = () =>
-  combineReducers({
-    session: persistReducer(sessionPersistConfig, session),
-    statusReducer
-  });
+const rootReducer = combineReducers({
+  session: persistReducer(sessionPersistConfig, session),
+  statusReducer
+});
 
 export default rootReducer;

--- a/src/state/reducers/sessionReducer.js
+++ b/src/state/reducers/sessionReducer.js
@@ -1,5 +1,10 @@
-import { createReducer } from '@reduxjs/toolkit';
-import { login, signUp, logout, updateSession } from 'state/actions/userActions';
+import { createSlice } from '@reduxjs/toolkit';
+import {
+  loginFulfilled,
+  logoutFulfilled,
+  signUpFulfilled,
+  updateSession
+} from 'state/actions/userActions';
 
 const initialState = {
   authenticated: false,
@@ -7,18 +12,22 @@ const initialState = {
   info: {}
 };
 
-const actionHandlers = {
-  [login.fulfilled]: (state, { payload }) => {
-    state.user = payload;
-  },
-  [signUp.fulfilled]: (state, { payload }) => {
-    state.user = payload;
-  },
-  [updateSession]: (state, { payload }) => {
-    state.info = payload;
-    state.authenticated = true;
-  },
-  [logout.fulfilled]: () => initialState
-};
+const sessionSlice = createSlice({
+  name: 'session',
+  initialState,
+  extraReducers: {
+    [loginFulfilled]: (state, { payload }) => {
+      state.user = payload;
+    },
+    [signUpFulfilled]: (state, { payload }) => {
+      state.user = payload;
+    },
+    [logoutFulfilled]: () => initialState,
+    [updateSession]: (state, { payload }) => {
+      state.info = payload;
+      state.authenticated = true;
+    }
+  }
+});
 
-export default createReducer(initialState, actionHandlers);
+export default sessionSlice.reducer;

--- a/src/state/reducers/sessionReducer.js
+++ b/src/state/reducers/sessionReducer.js
@@ -1,4 +1,4 @@
-import { createReducer } from '@rootstrap/redux-tools';
+import { createReducer } from '@reduxjs/toolkit';
 import { login, signUp, logout, updateSession } from 'state/actions/userActions';
 
 const initialState = {
@@ -8,17 +8,17 @@ const initialState = {
 };
 
 const actionHandlers = {
-  [login.success]: (state, { payload }) => {
+  [login.fulfilled]: (state, { payload }) => {
     state.user = payload;
   },
-  [signUp.success]: (state, { payload }) => {
+  [signUp.fulfilled]: (state, { payload }) => {
     state.user = payload;
   },
   [updateSession]: (state, { payload }) => {
     state.info = payload;
     state.authenticated = true;
   },
-  [logout.success]: () => initialState
+  [logout.fulfilled]: () => initialState
 };
 
 export default createReducer(initialState, actionHandlers);

--- a/src/state/reducers/statusReducer.js
+++ b/src/state/reducers/statusReducer.js
@@ -1,0 +1,38 @@
+import imm from 'immer';
+import { NOT_STARTED, FULFILLED, REJECTED, PENDING } from 'constants/actionStatusConstants';
+
+const handleAction = (state, action) => {
+  const { type, error } = action;
+
+  const matchesStart = /(.*)\/pending/.exec(type);
+  const matchesError = /(.*)\/rejected/.exec(type);
+  const matchesSuccess = /(.*)\/fulfilled/.exec(type);
+  const matchesReset = /(.*)\/reset/.exec(type);
+
+  let status = NOT_STARTED;
+  let key = null;
+
+  if (matchesStart) {
+    const [, requestName] = matchesStart;
+    key = requestName;
+    status = PENDING;
+  } else if (matchesReset) {
+    const [, requestName] = matchesReset;
+    key = requestName;
+    status = NOT_STARTED;
+  } else if (matchesError) {
+    const [, requestName] = matchesError;
+    key = requestName;
+    status = REJECTED;
+  } else if (matchesSuccess) {
+    const [, requestName] = matchesSuccess;
+    key = requestName;
+    status = FULFILLED;
+  }
+
+  if (key) state[key] = { status, error: matchesError ? error?.message : undefined };
+
+  return state;
+};
+
+export default (state = {}, action) => imm(state, draft => handleAction(draft, action));

--- a/src/state/store/configureStore.dev.js
+++ b/src/state/store/configureStore.dev.js
@@ -1,11 +1,11 @@
 import { createLogger } from 'redux-logger';
-import { persistStore } from 'redux-persist';
+import { persistStore, FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER } from 'redux-persist';
 import _ from 'lodash';
 import { configureStore } from '@reduxjs/toolkit';
 
 import reducer from 'state/reducers';
 
-export default () => {
+export default initialState => {
   const logger = createLogger({
     collapsed: true,
     predicate: (getState, { type }) => !_.startsWith(type, '@@router')
@@ -13,8 +13,14 @@ export default () => {
 
   const store = configureStore({
     reducer,
-    middleware: getDefaultMiddleware => getDefaultMiddleware().concat(logger),
-    enhancers: window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+    preloadedState: initialState,
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: {
+          ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER]
+        }
+      }).concat(logger),
+    devTools: true
   });
 
   if (module.hot) {

--- a/src/state/store/configureStore.dev.js
+++ b/src/state/store/configureStore.dev.js
@@ -1,31 +1,21 @@
-// This file merely configures the store for hot reloading.
-// This boilerplate file is likely to be the same for each project that uses Redux.
-// With Redux, the actual stores are in /reducers.
-
-import { createStore, compose, applyMiddleware } from 'redux';
 import { createLogger } from 'redux-logger';
 import { persistStore } from 'redux-persist';
 import _ from 'lodash';
-import { thunkMiddleware } from '@rootstrap/redux-tools';
+import { configureStore } from '@reduxjs/toolkit';
 
-import rootReducer from 'state/reducers';
+import reducer from 'state/reducers';
 
-export default function configureStore(initialState) {
+export default () => {
   const logger = createLogger({
     collapsed: true,
     predicate: (getState, { type }) => !_.startsWith(type, '@@router')
   });
 
-  const middlewares = [thunkMiddleware, logger];
-
-  const store = createStore(
-    rootReducer(),
-    initialState,
-    compose(
-      applyMiddleware(...middlewares),
-      window.__REDUX_DEVTOOLS_EXTENSION__ ? window.window.__REDUX_DEVTOOLS_EXTENSION__() : f => f // add support for Redux dev tools
-    )
-  );
+  const store = configureStore({
+    reducer,
+    middleware: getDefaultMiddleware => getDefaultMiddleware().concat(logger),
+    enhancers: window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+  });
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
@@ -38,4 +28,4 @@ export default function configureStore(initialState) {
   const persistor = persistStore(store);
 
   return { store, persistor };
-}
+};

--- a/src/state/store/configureStore.prod.js
+++ b/src/state/store/configureStore.prod.js
@@ -1,13 +1,10 @@
-import { createStore, compose, applyMiddleware } from 'redux';
 import { persistStore } from 'redux-persist';
-import { thunkMiddleware } from '@rootstrap/redux-tools';
+import { configureStore } from '@reduxjs/toolkit';
 
-import rootReducer from 'state/reducers';
+import reducer from 'state/reducers';
 
-export default function configureStore(initialState, isServerSide = false) {
-  const middlewares = [thunkMiddleware];
-
-  const store = createStore(rootReducer(), initialState, compose(applyMiddleware(...middlewares)));
+export default (isServerSide = false) => {
+  const store = configureStore({ reducer });
 
   if (isServerSide) {
     return { store };
@@ -16,4 +13,4 @@ export default function configureStore(initialState, isServerSide = false) {
   const persistor = persistStore(store);
 
   return { store, persistor };
-}
+};

--- a/src/state/store/configureStore.prod.js
+++ b/src/state/store/configureStore.prod.js
@@ -3,8 +3,11 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import reducer from 'state/reducers';
 
-export default (isServerSide = false) => {
-  const store = configureStore({ reducer });
+export default (initialState, isServerSide = false) => {
+  const store = configureStore({
+    reducer,
+    preloadedState: initialState
+  });
 
   if (isServerSide) {
     return { store };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,12 +1620,15 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@rootstrap/redux-tools@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@rootstrap/redux-tools/-/redux-tools-1.0.0.tgz#327c1bd1edbfe72946155f6de3d5b009f8b542ac"
-  integrity sha512-p+qK+oBwxIwfU4OYnGwf+tReS2otaNoAuoyXWNjdC7DN9ZhskmF2v88dzvqIlZZk23Hv5hk9Boz+NuS08/wkrA==
+"@reduxjs/toolkit@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.4.0.tgz#ee2e2384cc3d1d76780d844b9c2da3580d32710d"
+  integrity sha512-hkxQwVx4BNVRsYdxjNF6cAseRmtrkpSlcgJRr3kLUcHPIAMZAmMJkXmHh/eUEGTMqPzsYpJLM7NN2w9fxQDuGw==
   dependencies:
-    immer "^5.0.0"
+    immer "^7.0.3"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
 
 "@rootstrap/validate@1.0.0":
   version "1.0.0"
@@ -6441,10 +6444,10 @@ immer@5.0.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-5.0.0.tgz#07f462b7d95f7e86c214a861ecacd766d42b8c0a"
   integrity sha512-G7gRqKbi9NE025XVyqyTV98dxUOtdKvu/P1QRaVZfA55aEcXgjbxPdm+TlWdcSMNPKijlaHNz61DGPyelouRlA==
 
-immer@^5.0.0:
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-5.3.6.tgz#51eab8cbbeb13075fe2244250f221598818cac04"
-  integrity sha512-pqWQ6ozVfNOUDjrLfm4Pt7q4Q12cGw2HUZgry4Q5+Myxu9nmHRkWBpI0J4+MK0AxbdFtdMTwEGVl7Vd+vEiK+A==
+immer@^7.0.3:
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
+  integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -10691,10 +10694,23 @@ redux-persist@6.0.0:
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
   integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
 
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
 redux@4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
   integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
+
+redux@^4.0.0:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
@@ -10981,7 +10997,7 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-reselect@4.0.0:
+reselect@4.0.0, reselect@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10997,7 +10997,7 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-reselect@4.0.0, reselect@^4.0.0:
+reselect@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==


### PR DESCRIPTION
Closes #208 

This PR makes the migration from redux-tools to [redux-toolkit](https://github.com/reduxjs/redux-toolkit) while trying to make as fewer changes as possible.