### PR TITLE
Hotfix: Fix clean event on Github action

### DIFF
--- a/.github/workflows/pr-preview-clean.yml
+++ b/.github/workflows/pr-preview-clean.yml
@@ -14,11 +14,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      - name: Get branch name
-        uses: xt0rted/pull-request-comment-branch@v1
-        id: comment-branch
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate AWS bucket name
         uses: bluwy/substitute-string-action@v1
         id: bucket_name

--- a/.github/workflows/pr-preview-update.yml
+++ b/.github/workflows/pr-preview-update.yml
@@ -2,7 +2,7 @@ name: PR-Preview-Generator
 
 on:
   pull_request:
-    types: [edited, synchronize]
+    types: [edited]
 
 jobs:
   deploy:


### PR DESCRIPTION
## What & Why:
Remove an unnecessary step on the clean step of the deploy preview GitHub action.

