### PR TITLE
allow logout method to work when server responds with unauthorized error

### DIFF
--- a/src/httpClient/applyDefaultInterceptors.js
+++ b/src/httpClient/applyDefaultInterceptors.js
@@ -41,7 +41,7 @@ export default (store, client) => {
     },
     error => {
       if (error.response && error.response.status === UNAUTHORIZED) {
-        store.dispatch(logout());
+        store.dispatch(logout.success());
       }
 
       return Promise.reject(error);


### PR DESCRIPTION
## Fix: Adjust interceptor call when requesting logout to the backend

## What & Why:
Currently, when the logout action gets called, if the server responds with an error status, an uncontrolled loop can be triggered, and the authenticated reset state never happens.

With this change the client status will be forced to be logged out, which is a more desirable state in the react side regardless of what happened in the server.
