### PR TITLE
adding reset action in redux toolkit set up

### DIFF
--- a/src/constants/actionStatusConstants.js
+++ b/src/constants/actionStatusConstants.js
@@ -1,3 +1,4 @@
 export const PENDING = 'pending';
 export const FULFILLED = 'fulfilled';
 export const REJECTED = 'rejected';
+export const RESET = 'reset';

--- a/src/state/actions/userActions.js
+++ b/src/state/actions/userActions.js
@@ -1,6 +1,8 @@
-import { createAsyncThunk, createAction } from '@reduxjs/toolkit';
+import { createAction } from '@reduxjs/toolkit';
+
 import userService from 'services/userService';
 import parseError from 'utils/parseError';
+import createAsyncThunk from 'utils/createAsyncThunk';
 
 export const login = createAsyncThunk('user/login', async user => {
   try {

--- a/src/state/reducers/statusReducer.js
+++ b/src/state/reducers/statusReducer.js
@@ -1,6 +1,6 @@
 import { createReducer } from '@reduxjs/toolkit';
 
-import { FULFILLED, REJECTED, PENDING } from 'constants/actionStatusConstants';
+import { FULFILLED, REJECTED, PENDING, RESET } from 'constants/actionStatusConstants';
 
 const DELIMITER = '/';
 
@@ -28,6 +28,13 @@ export default createReducer({}, builder => {
       ({ type }) => type.endsWith(`/${PENDING}`),
       (state, { type }) => {
         state[getActionKey(type)] = { status: PENDING };
+      }
+    )
+    .addMatcher(
+      ({ type }) => type.endsWith(`/${RESET}`),
+      (state, { type }) => {
+        delete state[getActionKey(type)];
+        return state;
       }
     )
     .addDefaultCase(() => {});

--- a/src/utils/createAsyncThunk.js
+++ b/src/utils/createAsyncThunk.js
@@ -1,0 +1,9 @@
+import { createAsyncThunk, createAction } from '@reduxjs/toolkit';
+
+import { RESET } from 'constants/actionStatusConstants';
+
+export default (type, payload, options) => {
+  const thunk = createAsyncThunk(type, payload, options);
+  thunk.reset = createAction(`${type}/${RESET}`);
+  return thunk;
+};


### PR DESCRIPTION
<!---
  PR Title suggestion - [Type]: Action status reset

  Types:
    feat: (new feature for the user, not a new feature for build script)
    fix: (bug fix for the user, not a fix to a build script)
    docs: (changes to the documentation)
    style: (formatting, missing semi colons, etc; no production code change)
    refactor: (refactoring production code, eg. renaming a variable)
    test: (adding missing tests, refactoring tests; no production code change)
    chore: (updating grunt tasks etc; no production code change) 
--->

## What & Why:
We need a way to clean an action status from the status reducer. Generally, we use actions status to show errors or move to other pages. 
For instance, if we have a component which performs a request and it's rejected, in most cases we would like to show a message then. If we go to other page and then come back to the one with this component we will see the error again because it's stored in the status reducer.

## Tasks:
- [ ] Tested in different resolutions
- [x] Tested with SSR
- [x] Tested on Safari browser
- [ ] Design reviewed with design team

## Notes:
**Example**
we can use it as follows:
`const loginReset = useDispatch(login.reset);`

## Screenshots:
<!--- Screenshots and videos of the new behavior are great to understand the PR --->
