### PR TITLE
fix: GZIP_ENABLED flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 2. Install dependencies: `yarn` or `npm install`
 3. Create the environment variables files in root folder(.env.dev, .env.staging and .env.prod):
 
-`.env.example` example:
+`.env.example` [example](/.env.sample):
 
 ```
   API_URL=http://your-api-url.com
@@ -28,6 +28,7 @@
   AWS_REGION=region
   AWS_ACCESS_KEY_ID=key_id
   AWS_SECRET_ACCESS_KEY=secret_key
+  GZIP_ENABLED=false
 ```
 
 4. Start the dev server: `yarn start` or `npm start -s`

--- a/tools/s3.js
+++ b/tools/s3.js
@@ -4,6 +4,8 @@ import path from 'path';
 import mime from 'mime';
 import { consoleQuestion, JS_OR_CSS_REGEX } from './helpers';
 
+const GZIP_DEFAULT_ENABLED = false;
+
 class s3 {
   constructor(distFolder) {
     this.distPath = path.join(__dirname, distFolder);
@@ -55,7 +57,7 @@ class s3 {
         Body: fs.readFileSync(filePath),
         ContentType: mimeType,
       };
-      if (JSON.parse(process.env.GZIP_ENABLED) && JS_OR_CSS_REGEX.test(key)) {
+      if (JSON.parse(process.env.GZIP_ENABLED || GZIP_DEFAULT_ENABLED) && JS_OR_CSS_REGEX.test(key)) {
         params.ContentEncoding = 'gzip';
       }
       promises.push(this.client.putObject(params).promise());


### PR DESCRIPTION
# Fix GZIP_ENABLED flag 

## What & Why:

As the `GZIP_ENABLED` flag is mandatory (that is, if it is not set in the `.env`, the build does not work), a default value is added to s3 tools in order to prevent the build fail if it's not set.

Also `GZIP_ENABLED` is added to the `.env.example` table in the documentation.

