### PR TITLE
fix: set browser locale within Cypress tests

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,6 +24,7 @@ addMatchImageSnapshotCommand({
 });
 
 Cypress.on('window:before:load', win => {
+  Object.defineProperty(win.navigator, 'language', { value: 'en-US' });
   delete win.fetch;
 });
 


### PR DESCRIPTION
## What & Why:

Added language property set to english to browser within Cypress, so tests that expect certain strings in html tags don't fail because of internationalization issues. E.g. a test that expects the string 'Login' (as hardcoded in the code) will encounter the internationalized string 'Iniciar sesión' because of the browser default locale, causing the test to fail. Now the browser default locale will always be english.

## Screenshots:

- Testing output before fix
![image](https://user-images.githubusercontent.com/26825750/114050151-67c34700-9862-11eb-86c5-236e75cf4c00.png)

- Testing output after fix
![image](https://user-images.githubusercontent.com/26825750/114050274-8295bb80-9862-11eb-8aa3-103ffb46ac4d.png)

